### PR TITLE
Fix/repos page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # C extensions
 *.so
 
+
 # Distribution / packaging
 .Python
 build/
@@ -97,6 +98,7 @@ celerybeat-schedule
 .env
 .venv
 env/
+myenv/
 venv/
 ENV/
 env.bak/

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -11764,7 +11764,7 @@ html {
 .repo-container {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 20px;
 }
 


### PR DESCRIPTION
Existia um erro de espaçamento que foi retirado com esse novo deploy

Antes 

![image](https://github.com/user-attachments/assets/f35a60b1-05d2-4e6d-9837-dbbad8bb9c74)

Depois 

![image](https://github.com/user-attachments/assets/7b218af6-9a50-48bf-a36b-bca33973ea6e)


Também foi atualizado o gitignore